### PR TITLE
feat: adding continuous deployment to shuttle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Shuttle Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shuttle-hq/deploy-action@main
+        with:
+          deploy-key: ${{ secrets.SHUTTLE_API_KEY }}


### PR DESCRIPTION
Added github action that continously deploys to shuttle.
This will happen in every commit to main, which is protected to only be commited by merging a PR, which has to pass CI, and also have a review and conversations solved.