### PR TITLE
fix: get_last_day_from_month util method

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -11,14 +11,10 @@ pub fn get_first_day_from_month(month: u32) -> NaiveDate {
 }
 
 pub fn get_last_day_from_month(month: u32) -> NaiveDate {
-    Utc::now()
-        .with_day(1)
-        .unwrap()
-        .naive_utc()
-        .date()
-        .with_day(1)
-        .unwrap()
-        .with_month(month + 1)
-        .unwrap()
-        - chrono::Duration::days(1)
+    let first_day_of_month = get_first_day_from_month(month);
+
+    if first_day_of_month.month() == 12 {
+        return first_day_of_month.with_day(31).unwrap();
+    }
+    first_day_of_month.with_month(month + 1).unwrap() - chrono::Duration::days(1)
 }


### PR DESCRIPTION
Makes december get_last_day work properly.

Previously, when getting december day range, unwrap was called in month 13, which caused it to crash.
Now, if current_month is December, it just sets day to 31, without doing (month + 1) -1 day.